### PR TITLE
[npclogger] Fix Flags0/1/2/3 being written as zeroes to the db

### DIFF
--- a/addons/npcloggerv2.lua
+++ b/addons/npcloggerv2.lua
@@ -167,8 +167,8 @@ local function parseNpcUpdate(data)
         npc.x         = packet.x
         npc.y         = packet.z -- Backward compatibility, this should be y!
         npc.z         = packet.y -- Backward compatibility, this should be z!
-        npc.Flags0    = packet.Flags0
-        npc.Flags1    = packet.Flags1
+        npc.Flags0    = packet.Flags0_num
+        npc.Flags1    = packet.Flags1_num
         npc.Speed     = packet.Speed
         npc.SpeedBase = packet.SpeedBase
     end
@@ -176,9 +176,9 @@ local function parseNpcUpdate(data)
     if packet.SendFlg.General then
         npc.Hpp           = packet.Hpp
         npc.server_status = packet.server_status
-        npc.Flags1        = packet.Flags1
-        npc.Flags2        = packet.Flags2
-        npc.Flags3        = packet.Flags3
+        npc.Flags1        = packet.Flags1_num
+        npc.Flags2        = packet.Flags2_num
+        npc.Flags3        = packet.Flags3_num
         npc.SubAnimation  = packet.SubAnimation
     end
 


### PR DESCRIPTION
Does what it says on the tin

`packet.Flags0` etc are all tables and writing to the db fails. Just swap to using FlagsN_num instead and this fixes the db writing.

<img width="630" height="770" alt="image" src="https://github.com/user-attachments/assets/651f87c1-6e75-49b6-ab43-7332c5f761fd" />
